### PR TITLE
Force variable names to upper case, ftype "Rdata"

### DIFF
--- a/R/build.panel.r
+++ b/R/build.panel.r
@@ -274,6 +274,7 @@ build.panel <- function(datadir=NULL,fam.vars,ind.vars=NULL,SAScii=FALSE,heads.o
 		tmp.env  <- new.env()
 		load(file=ind.file,envir=tmp.env)
 		ind      <- get(ls(tmp.env),tmp.env)	# assign loaded dataset a new name
+		setnames(ind,names(ind), sapply(names(ind), toupper))	## convert all column names to uppercase
 		ind.dict <- NULL
 		ind      <- data.table(ind)
 	} else if (ftype=="csv") {


### PR DESCRIPTION
[ajdamico's script](https://github.com/ajdamico/usgsd/blob/master/Panel%20Study%20of%20Income%20Dynamics/download%20all%20microdata.R) generates "ind.rda" with all variable names in lower case (useful for typing variable names by hand). This generates error in build.panel.r function on line 348 which fails as it cannot find column names "ER30001..."

    348 yind <- copy(ind[,c(def.subsetter,unique(c(ind.subsetter,as.character(ind.vars[list(years[iy]),which(names(ind.vars)!="year"),with=FALSE])))),with=FALSE])

This pull request allows build.panel.r function to finish even when ftype "Rdata" INDyyyyER.xyz uses lower case variable names.